### PR TITLE
Add openpty/forkpty rust AIX implementations

### DIFF
--- a/src/unix/aix/mod.rs
+++ b/src/unix/aix/mod.rs
@@ -2962,7 +2962,7 @@ extern "C" {
         name: *const c_char,
         grp: *mut crate::group,
         buf: *mut c_char,
-        buflen: c_int,
+        buflen: size_t,
         result: *mut *mut crate::group,
     ) -> c_int;
     pub fn getgrset(user: *const c_char) -> *mut c_char;


### PR DESCRIPTION
# Description

Add `openpty` and `forkpty` implementations for AIX. NOTE this includes a copyright header since some code was copied from freebsd source
