### PR TITLE
work around for 'rust_test_suite'

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1807,12 +1807,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(target_os = "aix")] {
-        extern "C" {
-            pub fn cfmakeraw(termios: *mut crate::termios) -> c_int;
-            pub fn cfsetspeed(termios: *mut crate::termios, speed: crate::speed_t) -> c_int;
-        }
-    } else if #[cfg(not(any(
+    if #[cfg(not(any(
         target_os = "solaris",
         target_os = "illumos",
         target_os = "nto",


### PR DESCRIPTION
<!-- Thank you for submitting a PR!

We have the contribution guide, please read it if you are new here!
<https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md>

Please fill out the below template.
-->

# Description
The signature of `cfmakeraw()` of AIX is different from the Linux version.
AIX
```
extern int cfmakeraw(struct termios *);
```
Linux
```
void cfmakeraw(struct termios *termios_p);
```
This causes the `rustix` crate fails to build in the `rust_test_suite` test:
```
error[E0308]: mismatched types
   --> /home/xingxue/rust/dev/rust_test_suite/tests/maturin-rs/home/registry/src/index.crates.io-7f555b6b8ccf4919/rustix-0.38.41/src/backend/libc/termios/syscalls.rs:499:14
    |
499 |     unsafe { c::cfmakeraw(as_mut_ptr(termios).cast()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `i32`
```
The PR workarounds this issue to get `rust_test_suite` temporally test going. The proper fix should be in the `rustix` crate.

<!-- Add a short description about what this change does -->

# Sources

<!-- All API changes must have permalinks to headers. Common sources:

* Linux uapi https://github.com/torvalds/linux/tree/master/include/uapi
* Glibc https://github.com/bminor/glibc
* Musl https://github.com/bminor/musl
* Apple XNU https://github.com/apple-oss-distributions/xnu
* Android https://cs.android.com/android/platform/superproject/main

After navigating to the relevant file, click the triple dots and select "copy
permalink" if on GitHub, or l-r (links->commit) for the Android source to get a
link to the current version of the header.

If sources are closed, link to documentation or paste relevant C definitions.
-->

# Checklist

<!-- Please make sure the following has been done before submitting a PR,
or mark it as a draft if you are not sure. -->

- [ ] Relevant tests in `libc-test/semver` have been updated
- [ ] No placeholder or unstable values like `*LAST` or `*MAX` are
  included (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- [ ] Tested locally (`cd libc-test && cargo test --target mytarget`);
  especially relevant for platforms that may not be checked in CI

<!-- labels: is this PR a breaking change? If not, we can probably get it in a
0.2 release. Just uncomment the following:

@rustbot label +stable-nominated
-->
